### PR TITLE
[Fiber] Always push context before bailouts

### DIFF
--- a/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
+++ b/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
@@ -650,6 +650,19 @@ describe('ReactDOMFiber', () => {
       );
     });
 
+    it('keeps track of namespaces despite low priority bailout', () => {
+      assertNamespacesMatch(
+        <svg {...expectSVG}>
+          {/*
+            TODO: this relies on the magic `hidden` attribute in Fiber.
+            Figure out a better test.
+          */}
+          <foreignObject hidden={true} {...expectSVG} />
+          <image {...expectSVG} />
+        </svg>
+      );
+    });
+
     it('should unwind namespaces on uncaught errors', () => {
       function BrokenRender() {
         throw new Error('Hello');

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -407,6 +407,8 @@ module.exports = function<T, P, I, TI, C, CX>(
       // priority reconciliation first before we can get down here. However,
       // that is a bit tricky since workInProgress and current can have
       // different "hidden" settings.
+      // TODO: there is a test in ReactDOMFiber-test that uses `hidden` attribute.
+      // If we change the API for deprioritization we must change that test too.
       let child = workInProgress.progressedChild;
       while (child) {
         // To ensure that this subtree gets its priority reset, the children


### PR DESCRIPTION
When I first wrote the context code, I didn't fully understand how bailouts work. Even if a fiber bails out, it still has to complete. Therefore we should always push the context even if we later bail out.
