### PR TITLE
Fixing <s>some</s> *most* of the issues with links

### DIFF
--- a/docs/_data/nav_tutorial.yml
+++ b/docs/_data/nav_tutorial.yml
@@ -2,89 +2,89 @@
   items:
     - id: tutorial
       title: Before We Start
-      href: /react/tutorial/tutorial.html#before-we-start
+      href: /tutorial/tutorial.html#before-we-start
       forceInternal: true
       subitems:
-        - id: what-were-building 
+        - id: what-were-building
           title: What We're Building
-          href: /react/tutorial/tutorial.html#what-were-building
+          href: /tutorial/tutorial.html#what-were-building
           forceInternal: true
         - id: prerequisites
           title: Prerequisites
-          href: /react/tutorial/tutorial.html#prerequisites
+          href: /tutorial/tutorial.html#prerequisites
           forceInternal: true
         - id: how-to-follow-along
           title: How to Follow Along
-          href: /react/tutorial/tutorial.html#how-to-follow-along
+          href: /tutorial/tutorial.html#how-to-follow-along
           forceInternal: true
         - id: help-im-stuck
           title: Help, I'm Stuck!
-          href: /react/tutorial/tutorial.html#help-im-stuck
+          href: /tutorial/tutorial.html#help-im-stuck
           forceInternal: true
     - id: overview
       title: Overview
-      href: /react/tutorial/tutorial.html#overview
+      href: /tutorial/tutorial.html#overview
       forceInternal: true
       subitems:
         - id: what-is-react
           title: What is React?
-          href: /react/tutorial/tutorial.html#what-is-react
+          href: /tutorial/tutorial.html#what-is-react
           forceInternal: true
         - id: getting-started
           title: Getting Started
-          href: /react/tutorial/tutorial.html#getting-started
+          href: /tutorial/tutorial.html#getting-started
           forceInternal: true
         - id: passing-data-through-props
           title: Passing Data Through Props
-          href: /react/tutorial/tutorial.html#passing-data-through-props
+          href: /tutorial/tutorial.html#passing-data-through-props
           forceInternal: true
         - id: an-interactive-component
           title: An Interactive Component
-          href: /react/tutorial/tutorial.html#an-interactive-component
+          href: /tutorial/tutorial.html#an-interactive-component
           forceInternal: true
-        - id: developer-tools 
+        - id: developer-tools
           title: Developer Tools
-          href: /react/tutorial/tutorial.html#developer-tools
+          href: /tutorial/tutorial.html#developer-tools
           forceInternal: true
     - id: lifting-state-up
       title: Lifting State Up
-      href: /react/tutorial/tutorial.html#lifting-state-up
+      href: /tutorial/tutorial.html#lifting-state-up
       forceInternal: true
       subitems:
-        - id: why-immutability-is-important 
+        - id: why-immutability-is-important
           title: Why Immutability Is Important
-          href: /react/tutorial/tutorial.html#why-immutability-is-important
+          href: /tutorial/tutorial.html#why-immutability-is-important
           forceInternal: true
-        - id: functional-components 
+        - id: functional-components
           title: Functional Components
-          href: /react/tutorial/tutorial.html#functional-components
+          href: /tutorial/tutorial.html#functional-components
           forceInternal: true
         - id: taking-turns
           title: Taking Turns
-          href: /react/tutorial/tutorial.html#taking-turns
+          href: /tutorial/tutorial.html#taking-turns
           forceInternal: true
         - id: declaring-a-winner
           title: Declaring a Winner
-          href: /react/tutorial/tutorial.html#declaring-a-winner
+          href: /tutorial/tutorial.html#declaring-a-winner
           forceInternal: true
     - id: storing-a-history
       title: Storing A History
-      href: /react/tutorial/tutorial.html#storing-a-history
+      href: /tutorial/tutorial.html#storing-a-history
       forceInternal: true
       subitems:
         - id: showing-the-moves
           title: Showing the Moves
-          href: /react/tutorial/tutorial.html#showing-the-moves
+          href: /tutorial/tutorial.html#showing-the-moves
           forceInternal: true
         - id: keys
           title: Keys
-          href: /react/tutorial/tutorial.html#keys
+          href: /tutorial/tutorial.html#keys
           forceInternal: true
-        - id: implementing-time-travel 
+        - id: implementing-time-travel
           title: Implementing Time Travel
-          href: /react/tutorial/tutorial.html#implementing-time-travel
+          href: /tutorial/tutorial.html#implementing-time-travel
           forceInternal: true
         - id: wrapping-up
           title: Wrapping Up
-          href: /react/tutorial/tutorial.html#wrapping-up
+          href: /tutorial/tutorial.html#wrapping-up
           forceInternal: true

--- a/www/package.json
+++ b/www/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "babel-standalone": "^6.26.0",
     "docsearch.js": "^2.4.1",
-    "gatsby": "^1.8.16",
+    "gatsby": "^1.9.9",
     "gatsby-link": "^1.6.9",
     "gatsby-plugin-glamor": "^1.6.4",
     "gatsby-plugin-google-analytics": "^1.0.4",

--- a/www/src/components/LayoutFooter/Footer.js
+++ b/www/src/components/LayoutFooter/Footer.js
@@ -41,32 +41,32 @@ const Footer = () => (
         }}>
         <FooterNav>
           <FooterTitle>Docs</FooterTitle>
-          <FooterLink to="#">Quick Start</FooterLink>
-          <FooterLink to="#">Thinking in React</FooterLink>
-          <FooterLink to="#">Tutorial</FooterLink>
-          <FooterLink to="#">Advanced Guides</FooterLink>
+          <FooterLink to="/docs/hello-world.html">Quick Start</FooterLink>
+          <FooterLink to="/docs/thinking-in-react.html">Thinking in React</FooterLink>
+          <FooterLink to="/tutorial/tutorial.html">Tutorial</FooterLink>
+          <FooterLink to="/docs/jsx-in-depth.html">Advanced Guides</FooterLink>
         </FooterNav>
         <FooterNav>
           <FooterTitle>Community</FooterTitle>
-          <FooterLink to="#">Stack Overflow</FooterLink>
-          <FooterLink to="#">Discussion Forum</FooterLink>
-          <FooterLink to="#">Reactiflux Chat</FooterLink>
-          <FooterLink to="#">Facebook</FooterLink>
-          <FooterLink to="#">Twitter</FooterLink>
+          <FooterLink to="http://stackoverflow.com/questions/tagged/reactjs" target="_blank">Stack Overflow</FooterLink>
+          <FooterLink to="https://discuss.reactjs.org" target="_blank">Discussion Forum</FooterLink>
+          <FooterLink to="https://discord.gg/0ZcbPKXt5bZjGY5n" target="_blank">Reactiflux Chat</FooterLink>
+          <FooterLink to="https://www.facebook.com/react" target="_blank">Facebook</FooterLink>
+          <FooterLink to="https://twitter.com/reactjs" target="_blank">Twitter</FooterLink>
         </FooterNav>
         <FooterNav>
           <FooterTitle>Resources</FooterTitle>
-          <FooterLink to="#">Conferences</FooterLink>
-          <FooterLink to="#">Videos</FooterLink>
-          <FooterLink to="#">Examples</FooterLink>
-          <FooterLink to="#">Complementary Tools</FooterLink>
+          <FooterLink to="/community/conferences.html">Conferences</FooterLink>
+          <FooterLink to="/community/videos.html">Videos</FooterLink>
+          <FooterLink to="https://github.com/facebook/react/wiki/Examples" target="_blank">Examples</FooterLink>
+          <FooterLink to="https://github.com/facebook/react/wiki/Complementary-Tools" target="_blank">Complementary Tools</FooterLink>
         </FooterNav>
         <FooterNav>
           <FooterTitle>More</FooterTitle>
-          <FooterLink to="#">Blog</FooterLink>
-          <FooterLink to="#">GitHub</FooterLink>
-          <FooterLink to="#">React Native</FooterLink>
-          <FooterLink to="#">Acknowledgements</FooterLink>
+          <FooterLink to="/blog.html">Blog</FooterLink>
+          <FooterLink to="https://github.com/facebook/react" target="_blank">GitHub</FooterLink>
+          <FooterLink to="http://facebook.github.io/react-native/" target="_blank">React Native</FooterLink>
+          <FooterLink to="/acknowledgements.html">Acknowledgements</FooterLink>
         </FooterNav>
         <section
           css={{
@@ -80,7 +80,7 @@ const Footer = () => (
               paddingTop: 40,
             },
           }}>
-          <a href="https://code.facebook.com/projects/">
+          <a href="https://code.facebook.com/projects/" target="_blank">
             <img
               alt="Facebook Open Source"
               css={{

--- a/www/src/components/LayoutFooter/FooterLink.js
+++ b/www/src/components/LayoutFooter/FooterLink.js
@@ -14,7 +14,7 @@
 import React from 'react';
 import {colors} from 'theme';
 
-const FooterLink = ({children, to}) => (
+const FooterLink = ({children, target, to}) => (
   <a
     css={{
       fontWeight: 300,
@@ -23,7 +23,8 @@ const FooterLink = ({children, to}) => (
         color: colors.brand,
       },
     }}
-    href={to}>
+    href={to}
+    target={target}>
     {children}
   </a>
 );

--- a/www/src/templates/components/Sidebar/Section.js
+++ b/www/src/templates/components/Sidebar/Section.js
@@ -112,7 +112,7 @@ const CreateLink = (section, item) => {
     return (
       <Link
         css={[linkCss, isItemActive(item) && activeLinkCss]}
-        to={toAnchor(item.href)}>
+        to={item.href}>
         {item.title}
       </Link>
     );

--- a/www/src/theme.js
+++ b/www/src/theme.js
@@ -174,7 +174,7 @@ const sharedStyles = {
     },
 
     '& h3': {
-      marginTop: 45,
+      paddingTop: 45,
 
       [media.xlargeUp]: {
         fontSize: 25,

--- a/www/src/utils/slugify.js
+++ b/www/src/utils/slugify.js
@@ -16,5 +16,5 @@ import slugify from 'underscore.string/slugify';
 export default (string, directory) => {
   const filename = slugify(string) + '.html';
 
-  return directory ? `../${directory}/${filename}` : filename;
+  return directory ? `/${directory}/${filename}` : filename;
 };

--- a/www/yarn.lock
+++ b/www/yarn.lock
@@ -1078,7 +1078,7 @@ babel-register@^6.24.1:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@6.26.0:
+babel-runtime@6.26.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -3298,6 +3298,13 @@ gatsby-link@^1.6.9:
     prop-types "^15.5.8"
     ric "^1.3.0"
 
+gatsby-module-loader@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/gatsby-module-loader/-/gatsby-module-loader-1.0.4.tgz#f9cf32a255430f16807320252d73126f8567c697"
+  dependencies:
+    babel-runtime "^6.26.0"
+    loader-utils "^0.2.16"
+
 gatsby-plugin-glamor@^1.6.4:
   version "1.6.4"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-glamor/-/gatsby-plugin-glamor-1.6.4.tgz#43cdcab55fe381a6ef791157182ef24c78d59033"
@@ -3450,9 +3457,9 @@ gatsby-transformer-sharp@^1.6.1:
     fs-extra "^4.0.0"
     image-size "^0.6.0"
 
-gatsby@^1.8.16:
-  version "1.8.16"
-  resolved "https://registry.yarnpkg.com/gatsby/-/gatsby-1.8.16.tgz#76662e7572b37e785a87701b62e094ea4a5581bb"
+gatsby@^1.9.9:
+  version "1.9.10"
+  resolved "https://registry.yarnpkg.com/gatsby/-/gatsby-1.9.10.tgz#ef0f66aefd34c21ac42b2edf69eb03f9ab88aa78"
   dependencies:
     async "^2.1.2"
     babel-code-frame "^6.22.0"
@@ -3494,10 +3501,11 @@ gatsby@^1.8.16:
     friendly-errors-webpack-plugin "^1.6.1"
     front-matter "^2.1.0"
     fs-extra "^3.0.1"
+    gatsby-module-loader "^1.0.4"
     glob "^7.1.1"
     graphql "^0.10.3"
     graphql-relay "^0.5.1"
-    graphql-skip-limit "^1.0.2"
+    graphql-skip-limit "^1.0.3"
     gray-matter "^2.1.0"
     hapi "^8.5.1"
     history "^4.6.2"
@@ -3509,7 +3517,6 @@ gatsby@^1.8.16:
     json-loader "^0.5.2"
     json-stringify-safe "^5.0.1"
     json5 "^0.5.0"
-    loader-utils "^0.2.16"
     lodash "^4.17.4"
     lodash-id "^0.14.0"
     lowdb "^0.16.2"
@@ -3827,9 +3834,9 @@ graphql-relay@^0.5.1:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/graphql-relay/-/graphql-relay-0.5.2.tgz#40ff714efd60c2cd89e0bcc79e2afa6d87fa8673"
 
-graphql-skip-limit@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/graphql-skip-limit/-/graphql-skip-limit-1.0.2.tgz#9b72600ae9ccdecbe3a4edf521e51b14d63f979b"
+graphql-skip-limit@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/graphql-skip-limit/-/graphql-skip-limit-1.0.3.tgz#0809c6862ec1f589f7312c3a69d3fcb9232ad7c1"
   dependencies:
     babel-runtime "6.26.0"
 


### PR DESCRIPTION
**Problem:** The links in the 'Docs' page 404.

**Solution:** 
- remove the '..' in the urls which was added by our 'slugify' helper

**Problem:** The links in the footer are just empty.

**Solution:** 
- hard-code the urls in the footer, based on the old docs

**Problem:** The links in the tutorial lead to an error page.

**Solution:** 
- Stop removing the root of the url - GatsbyLink doesn't support this, and our old docs didn't do that.
- Change margin to padding above linked headers, so that jumping to them looks nice.

Before:
![screen shot 2017-08-30 at 3 01 45 pm](https://user-images.githubusercontent.com/1114467/29898094-d6e66f46-8d98-11e7-9402-31b7c2c2f5bf.png)

After:
![screen shot 2017-08-30 at 3 02 24 pm](https://user-images.githubusercontent.com/1114467/29898099-dca35c8c-8d98-11e7-89d9-839e960afe78.png)

Also updated Gatsby since I anticipated making PRs/changes to it, but that might not be needed, could omit that if you think we should wait to update.