### PR TITLE
Make timing explicit in test

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/store-test.js
+++ b/packages/react-devtools-shared/src/__tests__/store-test.js
@@ -1088,16 +1088,20 @@ describe('Store', () => {
       withErrorsOrWarningsIgnored(['test-only:'], () => {
         act(() => {
           ReactDOM.render(<Example />, container);
-
-          // Flush commit
-          jest.advanceTimersByTime(1);
-
-          expect(store).toMatchInlineSnapshot(`
-            [root]
-                <Example>
-          `);
-        });
+          // flush bridge operations
+          jest.runOnlyPendingTimers();
+        }, false);
       });
+
+      expect(store).toMatchInlineSnapshot(`
+        [root]
+            <Example>
+      `);
+
+      // flush count after delay
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      }, false);
 
       // After a delay, passive effects should be committed as well
       expect(store).toMatchInlineSnapshot(`

--- a/packages/react-devtools-shared/src/__tests__/utils.js
+++ b/packages/react-devtools-shared/src/__tests__/utils.js
@@ -14,7 +14,10 @@ import type Store from 'react-devtools-shared/src/devtools/store';
 import type {ProfilingDataFrontend} from 'react-devtools-shared/src/devtools/views/Profiler/types';
 import type {ElementType} from 'react-devtools-shared/src/types';
 
-export function act(callback: Function): void {
+export function act(
+  callback: Function,
+  recursivelyFlush: boolean = true,
+): void {
   const {act: actTestRenderer} = require('react-test-renderer');
   const {act: actDOM} = require('react-dom/test-utils');
 
@@ -24,13 +27,15 @@ export function act(callback: Function): void {
     });
   });
 
-  // Flush Bridge operations
-  while (jest.getTimerCount() > 0) {
-    actDOM(() => {
-      actTestRenderer(() => {
-        jest.runAllTimers();
+  if (recursivelyFlush) {
+    // Flush Bridge operations
+    while (jest.getTimerCount() > 0) {
+      actDOM(() => {
+        actTestRenderer(() => {
+          jest.runAllTimers();
+        });
       });
-    });
+    }
   }
 }
 


### PR DESCRIPTION
@bvaughn I found the test slightly confusing because the timing didn't appear in the test i.e. I could change the delay of `flushPendingErrorsAndWarningsAfterDelay` to 10s or 5s and it still passed. 

I copied the approach of `asyncAct` to not flush recursively so that we can visualize the timing in the test.

In the end we traded one implementation detail (advance timers by 1 to flush commit) for another (advance timers by 1000 to flush pending warnings). I'd argue we're more interested in the 1000ms delay here and it isn't just an implementation detail.

Feel free to close this if you don't think this improves readability of the test.

Ideally we'd have a dedicated method to flush bridge operations so that we don't run unrelated timers. Running timers implicitly is, to me, more confusing then having to advance it explicitly.